### PR TITLE
Fixed model creation (through save()) when id === null

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -943,7 +943,8 @@ steal.plugins('jquery/class', 'jquery/lang').then(function() {
 		 * Returns if the instance is a new object
 		 */
 		isNew: function() {
-			return (this[this.Class.id] === undefined); //if null or undefined
+			var id = this[this.Class.id];
+			return (id === undefined || id === null); //if null or undefined
 		},
 		/**
 		 * Saves the instance if there are no errors.  


### PR DESCRIPTION
Currently, when save() is called on a new model and the id property is null, it will try to update the model instance instead of create it. This is because isNew() now does a === comparison against undefined (according to the commit logs, this was result of a JSLint cleanup).

I believe the intention is to create the model instance when id is null or undefined, hence this change. I've written it this way to keep JSLint happy; obviously the easiest way to fix this is to revert to a == comparison.
