### PR TITLE
view from inline template doesn't take type='text/<type>' into account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .tmp*
 dist
+*.swp

--- a/view/test/qunit/view_test.js
+++ b/view/test/qunit/view_test.js
@@ -68,3 +68,13 @@ test("hookup", function(){
 	
 	$("#qunit-test-area").html("//jquery/view/test/qunit/hookup.ejs",{}); //makes sure no error happens
 })
+
+test("inline templates other than 'tmpl' like ejs", function(){
+        $("#qunit-test-area").html("");
+
+        $("#qunit-test-area").html($('<script type="test/ejs" id="test_ejs"><span id="new_name"><%= name %></span></script>'));
+
+        $("#qunit-test-area").html('test_ejs', {name: 'Henry'});
+        equal( $("#new_name").text(), 'Henry');
+	$("#qunit-test-area").html("");
+})

--- a/view/view.js
+++ b/view/view.js
@@ -208,6 +208,11 @@ steal.plugins("jquery").then(function( $ ) {
 	$view = $.View = function( view, data, helpers, callback ) {
 		var suffix = view.match(/\.[\w\d]+$/),
 			type, el, id, renderer, url = view;
+                // if we have an inline template, derive the suffix from the 'text/???' part
+                // this only supports '<script></script>' tags
+                if ( el = document.getElementById(view)) {
+                  suffix = el.type.match(/\/[\d\w]+$/)[0].replace(/^\//, '.');
+                }
 		if ( typeof helpers === 'function' ) {
 			callback = helpers;
 			helpers = undefined;


### PR DESCRIPTION
When you have the following code:

html:
      <script type='text/ejs' id='tmp_1'><span><%= name %></span></script>

js:
      var view = $.View('tmp_1', { name: 'Henry' });

the view is considered as a 'tmpl' type of view, current code doesn't look at the 'type' attribute.

This change fixes this.
