### PR TITLE
Removing HTML element with controller and Tie shouldn't crash

### DIFF
--- a/tie/test/qunit/qunit.js
+++ b/tie/test/qunit/qunit.js
@@ -80,6 +80,24 @@ steal
 		ok(tie._destroyed, "Tie is destroyed")
 	})
 	
+	test("removing html element removes the tie", function() {
+		var person1 = new Person({age: 5});
+		var inp = $("<div/>").appendTo( $("#qunit-test-area") );
+		
+		$.Controller("Foo",{
+			val : function(value) {}
+		});
+		
+		inp.foo().tie(person1,"age");
+		var foo = inp.controller('foo'),
+			tie = inp.controller('tie');
+
+		inp.remove(); // crashes here
+		
+		ok(foo._destroyed, "Foo is destroyed");
+		ok(tie._destroyed, "Tie is destroyed")
+	});
+	
 	test("tie on a specific controller", function(){});
 	
 	test("no controller with val, only listen", function(){


### PR DESCRIPTION
Adding a test that demonstrates that removing HTML element that has a controller and a Tie on it crashes with "Tie controller instance has been deleted"
