### PR TITLE
Calling _super() in derived class fails if parent doesn't have init defined.

### DIFF
--- a/class/test/qunit/class_test.js
+++ b/class/test/qunit/class_test.js
@@ -179,3 +179,21 @@ test("Creating without extend", function(){
 	});
 	new Foo().dude(true);
 })
+
+test("Super in derived when parent doesn't have init", function(){
+	$.Class.extend("Parent",{
+	});
+	
+	Parent.extend("Derived",{
+		init : function(){
+			this._super();
+		}
+	});
+
+	try {
+		new Derived();
+		ok(true, "Can call super in init safely")
+	} catch (e) {
+		ok(false, "Failed to call super in init with error: " + e)
+	}
+})


### PR DESCRIPTION
Adding a test that demonstrates that calling this._super() in the init of the derived class fails with error if parent class doesn't have init defined.

I consider this a valid use case which shouldn't fail.
