### PR TITLE
Derived models should inherit parent attributes and their defaults

### DIFF
--- a/model/test/qunit/model_test.js
+++ b/model/test/qunit/model_test.js
@@ -177,3 +177,39 @@ test("Empty uses fixtures", function(){
 		equals(things.length, 10,"got 10 things")
 	})
 })
+
+test("Inherits base attributes & defaults", function(){
+	$.Model.extend("Test.Parent", {
+		attributes: {
+			parent: 'string',
+			override_default: 'string'
+		},
+
+		defaults: {
+			parent: 'parent',
+			override_default: 'parent'
+		}
+	}, {
+	});	
+
+	Test.Parent.extend("Test.Derived", {
+		attributes: {
+			derived: 'string'
+		},
+
+		defaults: {
+			derived: 'derived',
+			override_default: 'derived'
+		}
+	}, {
+	});
+
+	var parent = new Test.Parent();
+	equals(parent.parent, 'parent', 'Parent attr is initialized from default');
+
+	var derived = new Test.Derived();
+	equals(derived.derived, 'derived', 'Derived explicitly defined attr is initialized from default')
+	ok(derived.parent !== undefined, 'Derived inherits Parent attr')
+	equals(derived.parent, 'parent', 'Derived inherited attr is initialized from inherited default');
+	equals(derived.override_default, 'derived', 'Derived inherited attr is initialized from overrided default');
+})

--- a/model/test/qunit/model_test.js
+++ b/model/test/qunit/model_test.js
@@ -190,6 +190,9 @@ test("Inherits base attributes & defaults", function(){
 			override_default: 'parent'
 		}
 	}, {
+		access_parent: function(name) {
+			equals(this.parent, 'parent', name + ' instance can access Parent attr');
+		}
 	});	
 
 	Test.Parent.extend("Test.Derived", {
@@ -206,10 +209,12 @@ test("Inherits base attributes & defaults", function(){
 
 	var parent = new Test.Parent();
 	equals(parent.parent, 'parent', 'Parent attr is initialized from default');
+	parent.access_parent('Parent');
 
 	var derived = new Test.Derived();
 	equals(derived.derived, 'derived', 'Derived explicitly defined attr is initialized from default')
 	ok(derived.parent !== undefined, 'Derived inherits Parent attr')
 	equals(derived.parent, 'parent', 'Derived inherited attr is initialized from inherited default');
 	equals(derived.override_default, 'derived', 'Derived inherited attr is initialized from overrided default');
+	derived.access_parent('Derived');
 })


### PR DESCRIPTION
Adding a test case that demonstrates that derived models do not inherit parent attributes and their defaults
