### PR TITLE
Conflict with identity function

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -759,6 +759,10 @@ steal.plugins('jquery/class', 'jquery/lang').then(function() {
 			if (!attributes ) {
 				return null;
 			}
+			if (attributes.identity !== undefined) {
+				attributes[this.identityMap || 'identity_'] = attributes.identity;
+				delete attributes.identity;
+			}
 			return new this(
 				// checks for properties in an object (like rails 2.0 gives);
 				isObject(attributes[this.singularName]) || 

--- a/model/test/person.json
+++ b/model/test/person.json
@@ -1,4 +1,5 @@
 {
  "id" : 5,
- "name" : "Justin"
+ "name" : "Justin",
+ "identity" : "zero"
 }

--- a/model/test/qunit/model_test.js
+++ b/model/test/qunit/model_test.js
@@ -65,6 +65,7 @@ test("findAll deferred", function(){
 		equals(people.length, 1, "we got a person back");
 		equals(people[0].name, "Justin", "Got a name back");
 		equals(people[0].Class.shortName, "Person", "got a class back");
+		equals(poeple[0].identity_, "zero", "identity field renamed to _identity");
 		start();
 	})
 });


### PR DESCRIPTION
If the data coming back from the server for a model has a field named "identity" this will cause a conflict and error within JMVC since model has a function called identity. This fix renamed any incoming fields named "identity" to "identity_"

It also allows the user to specify what it is renamed to by specifying: identityMap: "someNewName" within the static section of the model as is done with the "id" field.

I have also updated the unit tests.
