### PR TITLE
Addresses issue with the propagation of the resize "event"

### DIFF
--- a/event/resize/resize.js
+++ b/event/resize/resize.js
@@ -44,6 +44,11 @@ steal.plugins('jquery/event').then(function( $ ) {
 	 * an element with the first resize event 
 	 * handler.  There it will move the event in the opposite direction, calling the element's
 	 * children's resize event handlers.
+	 *
+	 * If your intent is to call resize without bubbling and only trigger child element's handlers,
+	 * use the following:
+	 *
+	 *     $("#foo").trigger("resize", false);
 	 * 
 	 * ## Stopping Children Updates
 	 * 
@@ -106,9 +111,10 @@ steal.plugins('jquery/event').then(function( $ ) {
 				if ( resizeCount === 0 ) {
 					// prevent others from doing what we are about to do
 					resizeCount++;
-
+					var where = data === false ? ev.target : this
+					console.log(where, data);
 					//trigger all this element's handlers
-					$.event.handle.call(this, ev);
+					$.event.handle.call(where, ev);
 					if ( ev.isPropagationStopped() ) {
 						resizeCount--;
 						return;
@@ -121,7 +127,7 @@ steal.plugins('jquery/event').then(function( $ ) {
 						child, sub;
 
 					// if index == -1 it's the window
-					while (++index < length && (child = resizers[index]) && (isWindow || $.contains(this, child)) ) {
+					while (++index < length && (child = resizers[index]) && (isWindow || $.contains(where, child)) ) {
 
 						// call the event
 						$.event.handle.call(child, ev);

--- a/event/resize/resize_test.js
+++ b/event/resize/resize_test.js
@@ -1,55 +1,69 @@
-steal.plugins('funcunit/qunit','jquery/event/resize').then(function(){
 
-module("jquery/event/resize")
+steal.plugins('funcunit/qunit', 'jquery/event/resize').then(function() {
+
+	module("jquery/event/resize")
 
 
-test("resize hits only children in order", function(){
-	var ids = []
-		record = function(ev){
+	test("resize hits only children in order", function() {
+		var ids = []
+		record = function( ev ) {
 			ids.push(this.id ? this.id : this)
 		},
-		divs = $("#qunit-test-area")
-		.html("<div id='1'><div id='1.1'></div><div id='1.2'></div></div><div id='2'></div>")
-		.find('div').bind('resize',record);
-		
-	$(document.body).bind('resize',record);
-	
-	$("#qunit-test-area").children().eq(0).trigger("resize");
-	
-	same(ids, ['1','1.1','1.2'])
-	
-	ids= [];
-	$("#qunit-test-area").trigger("resize");
-	same(ids, [document.body, '1','1.1','1.2','2']);
-	
-	ids= [];
-	$(window).trigger("resize");
-	same(ids, [document.body, '1','1.1','1.2','2']);
-	
-	$(document.body).unbind('resize',record);
-});
+			divs = $("#qunit-test-area").html("<div id='1'><div id='1.1'></div><div id='1.2'></div></div><div id='2'></div>").find('div').bind('resize', record);
 
-test("resize stopping prop", function(){
-	var ids = []
-		record = function(ev){
-			
+		$(document.body).bind('resize', record);
+
+		$("#qunit-test-area").children().eq(0).trigger("resize");
+
+		same(ids, ['1', '1.1', '1.2'])
+
+		ids = [];
+		$("#qunit-test-area").trigger("resize");
+		same(ids, [document.body, '1', '1.1', '1.2', '2']);
+
+		ids = [];
+		$(window).trigger("resize");
+		same(ids, [document.body, '1', '1.1', '1.2', '2']);
+
+		$(document.body).unbind('resize', record);
+	});
+
+	test("resize stopping prop", function() {
+		var ids = []
+		record = function( ev ) {
+
 			ids.push(this.id ? this.id : this)
-			if(this.id == '1'){
+			if ( this.id == '1' ) {
 				ev.stopPropagation();
 			}
 		},
-		divs = $("#qunit-test-area")
-		.html("<div id='1'><div id='1.1'></div><div id='1.2'></div></div><div id='2'></div>")
-		.find('div').bind('resize',record);
-		
-	$(document.body).bind('resize',record);
+			divs = $("#qunit-test-area").html("<div id='1'><div id='1.1'></div><div id='1.2'></div></div><div id='2'></div>").find('div').bind('resize', record);
 
-	$(window).trigger("resize");
-	same(ids, [document.body, '1','2']);
-	
-	$(document.body).unbind('resize',record);
-});
+		$(document.body).bind('resize', record);
 
+		$(window).trigger("resize");
+		same(ids, [document.body, '1', '2']);
+
+		$(document.body).unbind('resize', record);
+	});
+
+	test("resize event cascades from target", function() {
+
+		var ids = [],
+			record = function( ev ) {
+				ids.push(this.id ? this.id : this);
+			},
+
+			divs = $("#qunit-test-area").html("<div id='1'><div id='1.1'><div id='1.1.1'></div></div></div>");
+
+		divs.find("#1\\.1\\.1").bind("resize", record);
+		divs.find("#1").bind("resize", record);
+
+		$("#1\\.1").trigger("resize", [false]);
+		same(ids, ['1.1.1']);
+
+		$("#qunit-test-area").empty();
+	});
 
 
 })


### PR DESCRIPTION
Currently the "resize" event bubbles through elements until a suitable handler is found. Passing an array of [false] allows for the resize only to occur within child elements of the triggered element.
