### PR TITLE
The distance calculation on mousemove was missing a Math.sqrt call.

### DIFF
--- a/event/drag/drag.js
+++ b/event/drag/drag.js
@@ -171,7 +171,7 @@ steal.plugins('jquery/event', 'jquery/lang/vector', 'jquery/event/livehack').the
 		},
 		mousemove: function( docEl, ev ) {
 			if (!this.moved ) {
-				var dist = Math.pow( ev.pageX - this.event.pageX, 2 ) + Math.pow( ev.pageY - this.event.pageY, 2 );
+				var dist = Math.sqrt( Math.pow( ev.pageX - this.event.pageX, 2 ) + Math.pow( ev.pageY - this.event.pageY, 2 ));
 				if(dist < this._distance){
 					return false;
 				}


### PR DESCRIPTION
The distance calculation on mousemove was missing a Math.sqrt call. It now calculates distance correctly.
