### PR TITLE
Fix for automatically generated view paths of controllers in sub directories

### DIFF
--- a/controller/view/view.js
+++ b/controller/view/view.js
@@ -4,10 +4,14 @@ steal.plugins('jquery/controller', 'jquery/view').then(function( $ ) {
 	};
 
 	var calculatePosition = function( Class, view, action_name ) {
-		var slashes = Class.fullName.replace(/\./g, "/"),
-			hasControllers = slashes.indexOf("/Controllers/" + Class.shortName) != -1,
-			path = jQuery.String.underscore(slashes.replace("/Controllers/" + Class.shortName, "")),
-			controller_name = Class._shortName,
+		var classParts = Class.fullName.split('.'),
+			classPartsWithoutPrefix = classParts.slice(0);
+		classPartsWithoutPrefix.splice(0, 2); // Remove prefix (usually 2 elements)
+		
+		var classPartsWithoutPrefixSlashes = classPartsWithoutPrefix.join('/'),
+			hasControllers = (classParts.length > 2) && classParts[1] == 'Controllers',
+			path = classParts[0].toLowerCase(),
+			controller_name = classPartsWithoutPrefix.join('/').toLowerCase(),
 			suffix = (typeof view == "string" && view.match(/\.[\w\d]+$/)) || jQuery.View.ext;
 
 		//calculate view


### PR DESCRIPTION
I noticed that the automatically generated view path is not consistent for controller in sub directories like Myproject.Controllers.Foo.Bar. If you used this.view() in that controller, it would search in myproject/controllers/foo/bar/views/ instead of myproject/views/foo/bar/:

```
$.Controller.extend("Myproject.Controllers.Foo.Bar", {
   init: function() {
      // Did load myproject/controllers/foo/bar/views/init.ejs
      this.element.html(this.view());  
   }
});
```

Please review my changes - maybe it's possible to minimize the code even further or improve performance. Or the strange view path is a feature and not a bug?
