### PR TITLE
Prevent controller/view from duplicating suffix when suffix is present

### DIFF
--- a/controller/view/test/qunit/controller_view_test.js
+++ b/controller/view/test/qunit/controller_view_test.js
@@ -18,5 +18,22 @@ steal('jquery/controller/view','jquery/view/micro','funcunit/qunit')  //load qun
 		ok(/Hello World/i.test($('#cont_view').text()),"view rendered")
 	});
 	
+	test("test.suffix.doubling", function(){
+		
+		$.Controller.extend("jquery.Controller.View.Test.Qunit",{
+			init: function() {
+				this.element.html(this.view('init.micro'))
+			}
+		})
+		
+		jQuery.View.ext = ".ejs"; // Reset view extension to default
+		equal(".ejs", jQuery.View.ext); 
+		
+		$("#qunit-test-area").append("<div id='suffix_test_cont_view'/>");
+		
+		new jquery.Controller.View.Test.Qunit( $('#suffix_test_cont_view') );
+		
+		ok(/Hello World/i.test($('#suffix_test_cont_view').text()),"view rendered")
+	});
 });
 

--- a/controller/view/view.js
+++ b/controller/view/view.js
@@ -8,7 +8,7 @@ steal('jquery/controller', 'jquery/view').then(function( $ ) {
 			hasControllers = slashes.indexOf("/Controllers/" + Class.shortName) != -1,
 			path = jQuery.String.underscore(slashes.replace("/Controllers/" + Class.shortName, "")),
 			controller_name = Class._shortName,
-			suffix = (typeof view == "string" && view.match(/\.[\w\d]+$/)) || jQuery.View.ext;
+	        suffix = (typeof view == "string" && /\.[\w\d]+$/.test(view)) ? "" : jQuery.View.ext;
 
 		//calculate view
 		if ( typeof view == "string" ) {


### PR DESCRIPTION
alternate fix for https://github.com/jupiterjs/jquerymx/pull/29

current master code duplicates suffix if a view template has an explicit suffix

``` javascript
this.view('list'); // results in a fetch for 'list.ejs' 
this.view('list.mustache'); // results in 'list.mustache.mustache' s/b 'list.mustache'
```

I've added a test to ensure this covers this case, the existing test for controller/view covers the first case.

The case where a non string view request (a DOM element) is unchanged.
