### PR TITLE
EJS templates should escape HTML by default

### DIFF
--- a/view/ejs/ejs.js
+++ b/view/ejs/ejs.js
@@ -94,15 +94,15 @@ steal('jquery/view', 'jquery/lang/rsplit').then(function( $ ) {
 	 *     
 	 *         <% alert('hello world') %>
 	 *     
-	 *   - <code>&lt;%= CODE %&gt;</code> - Runs JS Code and writes the result into the result of the template.
+	 *   - <code>&lt;%= CODE %&gt;</code> - Runs JS Code and writes the _escaped_ result into the result of the template.
 	 *     For example:
 	 *     
 	 *         <h1><%= 'hello world' %></h1>
-	 *        
-	 *   - <code>&lt;%~ CODE %&gt;</code> - Runs JS Code and writes the _escaped_ result into the result of the template.
+	 *         
+	 *   - <code>&lt;%== CODE %&gt;</code> - Runs JS Code and writes the _unescaped_ result into the result of the template.
 	 *     For example:
 	 *     
-	 *         <%~ 'hello world' %>
+	 *         <h1><%== '<span>hello world</span>' %></h1>
 	 *         
 	 *   - <code>&lt;%%= CODE %&gt;</code> - Writes <%= CODE %> to the result of the template.  This is very useful for generators.
 	 *     

--- a/view/ejs/ejs.js
+++ b/view/ejs/ejs.js
@@ -286,12 +286,11 @@ steal('jquery/view', 'jquery/lang/rsplit').then(function( $ ) {
 			eeLeft : left + '%==',
 			eLeft: left + '%=',
 			cmnt: left + '%#',
-			cleanLeft: left+"%~",
 			scan : scan,
 			lines : 0
 		});
-		scanner.splitter = new RegExp("(" + [scanner.dLeft, scanner.dRight, scanner.eeLeft, scanner.eLeft, scanner.cleanLeft,
-		scanner.cmnt, scanner.left, scanner.right + '\n', scanner.right, '\n'].join(")|(").
+		scanner.splitter = new RegExp("(" + [scanner.dLeft, scanner.dRight, scanner.eeLeft, scanner.eLeft, 
+			scanner.cmnt, scanner.left, scanner.right + '\n', scanner.right, '\n'].join(")|(").
 			replace(/\[/g,"\\[").replace(/\]/g,"\\]") + ")");
 		return scanner;
 	},
@@ -327,7 +326,6 @@ steal('jquery/view', 'jquery/lang/rsplit').then(function( $ ) {
 					case scanner.left:
 					case scanner.eLeft:
 					case scanner.eeLeft:
-					case scanner.cleanLeft:
 					case scanner.cmnt:
 						startTag = token;
 						if ( content.length > 0 ) {
@@ -359,11 +357,8 @@ steal('jquery/view', 'jquery/lang/rsplit').then(function( $ ) {
 								buff.push(content, ";");
 							}
 							break;
-						case scanner.cleanLeft : 
-							buff.push(insert_cmd, "(jQuery.EJS.clean(", content, ")));");
-							break;
 						case scanner.eLeft:
-							buff.push(insert_cmd, "(jQuery.EJS.text(", content, ")));");
+							buff.push(insert_cmd, "(jQuery.EJS.clean(", content, ")));");
 							break;
 						case scanner.eeLeft:
 							buff.push(insert_cmd, "(jQuery.EJS.text(", content, ")));");

--- a/view/ejs/ejs.js
+++ b/view/ejs/ejs.js
@@ -251,8 +251,10 @@ steal('jquery/view', 'jquery/lang/rsplit').then(function( $ ) {
 	EJS.clean = function(text){
 		//return sanatized text
 		if(typeof text == 'string'){
-			return escapeHTML(text)
-		}else{
+			return escapeHTML(text);
+		} else if(typeof text == 'number') {
+			return text;
+		} else {
 			return "";
 		}
 	}

--- a/view/ejs/test/qunit/ejs_test.js
+++ b/view/ejs/test/qunit/ejs_test.js
@@ -61,12 +61,14 @@ test("multi line", function(){
 })
 
 test("escapedContent", function(){
-	var text = "<span><%= tags %></span><label>&amp;</label><input value='<%= quotes %>'/>";
+	var text = "<span><%= tags %></span><label>&amp;</label><strong><%= number %></strong><input value='<%= quotes %>'/>";
 	var compiled = new $.EJS({text: text}).render({tags: "foo < bar < car > zar > poo",
-							quotes : "I use 'quote' fingers \"a lot\""}) ;
+							quotes : "I use 'quote' fingers \"a lot\"",
+							number : 123}) ;
 	
 	var div = $('<div/>').html(compiled)
 	equals(div.find('span').text(), "foo < bar < car > zar > poo" );
+	equals(div.find('strong').text(), 123 );
 	equals(div.find('input').val(), "I use 'quote' fingers \"a lot\"" );
 	equals(div.find('label').html(), "&amp;" );
 })

--- a/view/ejs/test/qunit/ejs_test.js
+++ b/view/ejs/test/qunit/ejs_test.js
@@ -61,14 +61,24 @@ test("multi line", function(){
 })
 
 test("escapedContent", function(){
-	var text = "<span><%~ tags %></span><label>&amp;</label><input value='<%~ quotes %>'/>";
+	var text = "<span><%= tags %></span><label>&amp;</label><input value='<%= quotes %>'/>";
 	var compiled = new $.EJS({text: text}).render({tags: "foo < bar < car > zar > poo",
 							quotes : "I use 'quote' fingers \"a lot\""}) ;
 	
 	var div = $('<div/>').html(compiled)
 	equals(div.find('span').text(), "foo < bar < car > zar > poo" );
-	equals(div.find('input').val(), "I use 'quote' fingers \"a lot\"" )
-	equals(div.find('label').html(), "&amp;" )
-	
+	equals(div.find('input').val(), "I use 'quote' fingers \"a lot\"" );
+	equals(div.find('label').html(), "&amp;" );
 })
-//test("multi line sourc")
+
+test("unescapedContent", function(){
+	var text = "<span><%== tags %></span><div><%= tags %></div><input value='<%== quotes %>'/>";
+	var compiled = new $.EJS({text: text}).render({tags: "<strong>foo</strong><strong>bar</strong>",
+							quotes : "I use &#39;quote&#39; fingers &quot;a lot&quot;"}) ;
+	
+	var div = $('<div/>').html(compiled)
+	equals(div.find('span').text(), "foobar" );
+	equals(div.find('div').text(), "<strong>foo</strong><strong>bar</strong>" );
+	equals(div.find('span').html(), "<strong>foo</strong><strong>bar</strong>" );
+	equals(div.find('input').val(), "I use 'quote' fingers \"a lot\"" );
+})


### PR DESCRIPTION
According to http://forum.javascriptmvc.com/topic/escaping-with-ejs EJS templates should escape HTML by default in the next version (3.2). After reading this in the forum and telling everyone, we found out that this is not the case - so here are the changes needed. I really hope you didn't change the plans again? It's a mess if <%== and <%= do the same and you have to convert all tags to <%~ in order to use escaping (which should really be default for security reasons).
