### PR TITLE
Don't attempt to jQuerify argument if not HTML

### DIFF
--- a/view/ejs/ejs.js
+++ b/view/ejs/ejs.js
@@ -14,7 +14,7 @@ steal('jquery/view', 'jquery/lang/rsplit').then(function( $ ) {
 		isArray = $.isArray,
 		clean = function( content ) {
 				return content.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/"/g, '\\"');
-		}
+		},
 		// from prototype  http://www.prototypejs.org/
 		escapeHTML = function(content){
 			return content.replace(/&/g,'&amp;')

--- a/view/test/qunit/view_test.js
+++ b/view/test/qunit/view_test.js
@@ -149,7 +149,14 @@ test("jQuery.fn.hookup", function(){
 	$("#qunit-test-area").html("");
 	var els = $($.View("//jquery/view/test/qunit/hookup.ejs",{})).hookup();
 	$("#qunit-test-area").html(els); //makes sure no error happens
-})
+});
+
+test("non-HTML content in hookups", function(){
+	$("#qunit-test-area").html("<textarea></textarea>");
+	$.View.hookup(function(){});
+	$("#qunit-test-area textarea").val("asdf");
+	equals($("#qunit-test-area textarea").val(), "asdf");
+});
 
 /*test("bad url", function(){
 	$.View("//asfdsaf/sadf.ejs")

--- a/view/view.js
+++ b/view/view.js
@@ -537,7 +537,7 @@ steal("jquery").then(function( $ ) {
 
 	//---- ADD jQUERY HELPERS -----
 	//converts jquery functions to use views	
-	var convert, modify, isTemplate, getCallback, hookupView, funcs;
+	var convert, modify, isTemplate, isHTML, getCallback, hookupView, funcs;
 
 	convert = function( func_name ) {
 		var old = $.fn[func_name];
@@ -585,8 +585,8 @@ steal("jquery").then(function( $ ) {
 			break;
 		}
 
-		//if there are hookups, get jQuery object
-		if ( hasHookups && args[0]) {
+		// if there are hookups and we have HTML content, get jQuery object
+		if ( hasHookups && isHTML( args[0] ) ) {
 			hooks = $view.hookups;
 			$view.hookups = {};
 			args[0] = $(args[0]);
@@ -605,6 +605,11 @@ steal("jquery").then(function( $ ) {
 		var secArgType = typeof args[1];
 
 		return typeof args[0] == "string" && (secArgType == 'object' || secArgType == 'function') && !args[1].nodeType && !args[1].jquery;
+	};
+
+	// returns whether the argument is an HTML string (the way jQuery does it)
+	isHTML = function( str ) {
+	  return typeof str == "string" && ( str.charAt(0) === "<" && str.charAt( str.length - 1 ) === ">" && str.length >= 3 );
 	};
 
 	//returns the callback if there is one (for async view use)

--- a/view/view.js
+++ b/view/view.js
@@ -217,7 +217,7 @@ steal("jquery").then(function( $ ) {
 	 * the rendered result of the view.
 	 */
 
-	var $view, render, checkText, get, getRenderer
+	var $view, render, checkText, get, getRenderer,
 		isDeferred = function(obj){
 			return obj && $.isFunction(obj.always) // check if obj is a $.Deferred
 		},


### PR DESCRIPTION
I uncovered some interesting behavior in view/view.js, where the html, text, val, etc. jQuery methods are patched. Basically, if there are any hookups registered on $.View (which there were in my case), the first argument to val() is being wrapped in a jQuery object before delegation to the original method.

I've modified the code to check whether the argument to text, val, etc. is HTML before wrapping it in a jQuery object and performing the hookup logic.
