### PR TITLE
Cookbook example works out-of-the-box again

### DIFF
--- a/generate/templates/app/(application_name).js.ejs
+++ b/generate/templates/app/(application_name).js.ejs
@@ -1,7 +1,16 @@
 steal(
-	'./models/models.js',		// steals all your models
-	'./fixtures/fixtures.js',	// sets up fixtures for your models
-	'./<%= application_name %>.css', 					// application CSS file
+	'./models/models.js',           // steals all your models
+    './controllers/controllers.js', // steals all your controllers
+	{                               // sets up fixtures for your models
+        src: './fixtures/fixtures.js',
+        ignore: true
+    },
+
+	'jquery/view/ejs',				// client side templates
+	'jquery/dom/form_params',		// form data helper
+
+	'./<%= application_name %>.css',				// application CSS file
+
 	function(){						// configure your application
-		
+
 	})

--- a/generate/templates/app/controllers/controllers.js.ejs
+++ b/generate/templates/app/controllers/controllers.js.ejs
@@ -1,0 +1,9 @@
+// steal controller files
+
+steal(
+    "jquery/controller",            // a widget factory
+    "jquery/controller/view",       // lookup views with the controller's name
+    'jquery/controller/subscribe'	// subscribe to OpenAjax.hub
+).then( // steal your controllers here
+    //"./recipe_controller.js"
+)

--- a/generate/templates/app/models/models.js.ejs
+++ b/generate/templates/app/models/models.js.ejs
@@ -1,3 +1,7 @@
 // steal model files
 
-steal("jquery/model")
+steal(
+    "jquery/model"
+).then( // steal your models here
+    //'./recipe.js'
+)

--- a/generate/templates/scaffold/controllers/(underscore)_controller.js.ejs
+++ b/generate/templates/scaffold/controllers/(underscore)_controller.js.ejs
@@ -15,7 +15,7 @@ $.Controller.extend('<%=name.replace("Models","Controllers")%>',
  /**
  * When the page loads, gets all <%= plural %> to be displayed.
  */
- "{window} load": function(){
+ init: function(){
 	if(!$("#<%= underscore %>").length){
 	 $(document.body).append($('<div/>').attr('id','<%= underscore %>'));
 		 <%= name %>.findAll({}, this.callback('list'));

--- a/generate/templates/scaffold/views/(underscore)/init.ejs.ejs
+++ b/generate/templates/scaffold/views/(underscore)/init.ejs.ejs
@@ -10,7 +10,7 @@
 	</tr>
 	</thead>
 	<tbody>
-		<%%= $.View('//<%= appPath %>/views/<%= underscore %>/list',{<%=plural%>: <%=plural%>})%>
+		<%%== $.View('//<%= appPath %>/views/<%= underscore %>/list',{<%=plural%>: <%=plural%>})%>
 	</tbody>
 </table>
 <h2>New <%= underscore %></h2>

--- a/generate/templates/scaffold/views/(underscore)/list.ejs.ejs
+++ b/generate/templates/scaffold/views/(underscore)/list.ejs.ejs
@@ -1,5 +1,5 @@
 <%%for(var i = 0; i < <%=plural%>.length ; i++){%>
 	<tr <%%= <%=plural%>[i]%>>
-		<%%= $.View('//<%= appPath %>/views/<%= underscore%>/show',<%=plural%>[i])%>
+		<%%== $.View('//<%= appPath %>/views/<%= underscore%>/show',<%=plural%>[i])%>
 	</tr>
 <%%}%>


### PR DESCRIPTION
(Uncomment the recipe steal in controllers/controllers.js & models/models.js after scaffolding.)

It seems some of the recent changes caused the cookbook example to not work anymore. The changes I made:
- Where one view script includes another (e.g. list.ejs & init.ejs) <%%== should be used in the template so the unescaped script output is included.
- Added controllers/controllers.js similar to models/models.js where application controllers and common controller plugins (e.g. jquery/controller/view) can be included.
- Updated the application.js template to reflect the above.
- It seems the "{window} load" method in the recipe_controller does not work properly; I changed it to be the 'init' method which does work.
