### PR TITLE
Pass XHR object to callback

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -84,9 +84,9 @@ steal('jquery/class', 'jquery/lang/string', function() {
 		// makes a deferred request
 		makeRequest = function(self, type, success, error, method){
 			var deferred = $.Deferred(),
-				resolve = function(data){
-					self[method || type+"d"](data);
-					deferred.resolveWith(self,[self, data, type]);
+				resolve = function(data,statusText, jqXHR){
+					self[method || type+"d"](data,jqXHR);
+					deferred.resolveWith(self,[self, data, type,jqXHR]);
 				},
 				reject = function(data){
 					deferred.rejectWith(self, [data])


### PR DESCRIPTION
Hi,
I had to do this change because in some model callbacks I needed to access HTTP headers, unfortunatelly before this information was not available.
Can imagine this feature could be useful for others.

Regards,
Dmytro
