### PR TITLE
Allow controllers to inherit defaults from superclasses

### DIFF
--- a/controller/controller.js
+++ b/controller/controller.js
@@ -328,6 +328,9 @@ steal('jquery/class', 'jquery/lang/string', 'jquery/event/destroyed', function( 
 		 * @codeend
 		 */
 		setup: function() {
+			// Allow contollers to inherit "defaults" from superclasses as it done in $.Class
+			$.Class.setup.apply(this, arguments);
+
 			// if you didn't provide a name, or are controller, don't do anything
 			if (!this.shortName || this.fullName == "jQuery.Controller" ) {
 				return;

--- a/controller/controller_test.js
+++ b/controller/controller_test.js
@@ -221,4 +221,24 @@ test("pluginName", function() {
 	ok(ta.hasClass("existing_class"), "Existing class should still be there");
 })
 
+test("inherit defaults", function() {
+    $.Controller.extend("BaseController", {
+        defaults : {
+            foo: 'bar'
+        }
+    }, {});
+
+    BaseController.extend("InheritingController", {
+        defaults : {
+            newProp : 'newVal'
+        }
+    }, {});
+
+    ok(InheritingController.defaults.foo === 'bar', 'Class must inherit defaults from the parent class');
+    ok(InheritingController.defaults.newProp == 'newVal', 'Class must have own defaults');
+    var inst = new InheritingController($('<div/>'), {});
+    ok(inst.options.foo === 'bar', 'Instance must inherit defaults from the parent class');
+    ok(inst.options.newProp == 'newVal', 'Instance must have defaults of it`s class');
+});
+
 });


### PR DESCRIPTION
Allow controllers to inherit defaults from superclasses as it done in $.Class.

Normally, all classes inherited from $.Class will inherit all values from static 'defaults' property of all ancestors. However code for $.Controller overrides static method "setup" and this feature is lost for all subclasses of $.Controller. This fix will recover this feature for controllers.
