### PR TITLE
Fixed bug with plus sign in params

### DIFF
--- a/lang/string/deparam/deparam.js
+++ b/lang/string/deparam/deparam.js
@@ -43,8 +43,8 @@ steal('jquery', function($){
 					pair = [pair[0], pair.slice(1).join("=")]
 				}
 				
-				var key = decodeURIComponent(pair[0]), 
-					value = decodeURIComponent(pair[1]),
+				var key = decodeURIComponent(pair[0].replace(/\+/g, " ")), 
+					value = decodeURIComponent(pair[1].replace(/\+/g, " ")),
 					parts = key.match(keyBreaker);
 		
 				for ( var j = 0; j < parts.length - 1; j++ ) {


### PR DESCRIPTION
Fix for deparam.js - for proper string conversion to objects which have spaces in keys or values, so this code would work as expected:
`$.deparam($.param({"key with spaces" : "value with spaces"}))`
