### PR TITLE
Customizable default validation messages

### DIFF
--- a/model/validations/validations.js
+++ b/model/validations/validations.js
@@ -45,14 +45,12 @@ var validate = function(attrNames, options, proc) {
 	}
 	options = options || {};
 	attrNames = $.makeArray(attrNames)
-	var customMsg = options.message,
-		self = this;
 	
 	if(options.testIf && !options.testIf.call(this)){
 		return;
 	}
-	     
 	
+	var self = this;
 	$.each(attrNames, function(i, attrName) {
 		// Call the validate proc function in the instance context
 		if(!self.validations[attrName]){
@@ -66,14 +64,13 @@ var validate = function(attrNames, options, proc) {
    
 };
 
-
 $.extend($.Model, {
    /**
     * @function jQuery.Model.static.validate
     * @parent jquery.model.validations
     * Validates each of the specified attributes with the given function.  See [validation] for more on validations.
     * @param {Array|String} attrNames Attribute name(s) to to validate
-    * @param {Function} validateProc Function used to validate each given attribute. Returns true for valid and false otherwise. Function is called in the instance context and takes the value to validate
+    * @param {Function} validateProc Function used to validate each given attribute. Returns nothing if valid and an error message otherwise. Function is called in the instance context and takes the value to validate.
     * @param {Object} options (optional) Options for the validations.  Valid options include 'message' and 'testIf'.
     */
    validate: validate,

--- a/model/validations/validations.js
+++ b/model/validations/validations.js
@@ -77,6 +77,26 @@ $.extend($.Model, {
     * @param {Object} options (optional) Options for the validations.  Valid options include 'message' and 'testIf'.
     */
    validate: validate,
+   
+   /**
+    * @attribute validationMessages
+    * @parent jquery.model.validations
+    * The default validation error messages that will be returned by the 
+    * builtin validation methods. These can be overwritten by assigning
+    * new messages to $.Model.validationMessages in your application setup.
+    * 
+    * It is important to ensure that jquery/model/validations is included
+    * with steal before overwriting the messages otherwise the changes will
+    * be lost once it is loaded by steal later.
+    */
+   validationMessages : {
+       format      : "Is invalid",
+       inclusion   : "Is not a valid option (perhaps out of range)",
+       lengthShort : "Is too short",
+       lengthLong  : "Is too long",
+       presence    : "Can't be empty",
+       range       : "Is out of range"
+   },
 
    /**
     * @function jQuery.Model.static.validateFormatOf
@@ -93,7 +113,7 @@ $.extend($.Model, {
          if(  (typeof value != 'undefined' && value != '')
          	&& String(value).match(regexp) == null )
          {
-            return "is invalid";
+            return this.Class.validationMessages.format;
          }
       });
    },
@@ -114,7 +134,7 @@ $.extend($.Model, {
             return;
 
          if($.grep(inArray, function(elm) { return (elm == value);}).length == 0)
-            return "is not a valid option (perhaps out of range)";
+            return this.Class.validationMessages.inclusion;
       });
    },
 
@@ -130,10 +150,11 @@ $.extend($.Model, {
     */
    validateLengthOf: function(attrNames, min, max, options) {
       validate.call(this, attrNames, options, function(value) {
+         var msg = this.Class.validationMessages.length;
          if((typeof value == 'undefined' && min > 0) || value.length < min)
-            return "is too short (min=" + min + ")";
+            return this.Class.validationMessages.length.tooShort + " (min=" + min + ")";
          else if(typeof value != 'undefined' && value.length > max)
-            return "is too long (max=" + max + ")";
+            return this.Class.validationMessages.length.tooLong + " (max=" + max + ")";
       });
    },
 
@@ -148,7 +169,7 @@ $.extend($.Model, {
    validatePresenceOf: function(attrNames, options) {
       validate.call(this, attrNames, options, function(value) {
          if(typeof value == 'undefined' || value == "" || value === null)
-            return "can't be empty";
+            return this.Class.validationMessages.presence;
       });
    },
 
@@ -165,14 +186,9 @@ $.extend($.Model, {
    validateRangeOf: function(attrNames, low, hi, options) {
       validate.call(this, attrNames, options, function(value) {
          if(typeof value != 'undefined' && value < low || value > hi)
-            return "is out of range [" + low + "," + hi + "]";
+            return this.Class.validationMessages.range + " [" + low + "," + hi + "]";
       });
    }
 });
 
-
-
-
-
-	
 });

--- a/model/validations/validations.js
+++ b/model/validations/validations.js
@@ -95,12 +95,12 @@ $.extend($.Model, {
     * be lost once steal loads it later.
     */
    validationMessages : {
-       format      : "Is invalid",
-       inclusion   : "Is not a valid option (perhaps out of range)",
-       lengthShort : "Is too short",
-       lengthLong  : "Is too long",
-       presence    : "Can't be empty",
-       range       : "Is out of range"
+       format      : "is invalid",
+       inclusion   : "is not a valid option (perhaps out of range)",
+       lengthShort : "is too short",
+       lengthLong  : "is too long",
+       presence    : "can't be empty",
+       range       : "is out of range"
    },
 
    /**
@@ -155,11 +155,10 @@ $.extend($.Model, {
     */
    validateLengthOf: function(attrNames, min, max, options) {
       validate.call(this, attrNames, options, function(value) {
-         var msg = this.Class.validationMessages.length;
          if((typeof value == 'undefined' && min > 0) || value.length < min)
-            return this.Class.validationMessages.length.tooShort + " (min=" + min + ")";
+            return this.Class.validationMessages.lengthShort + " (min=" + min + ")";
          else if(typeof value != 'undefined' && value.length > max)
-            return this.Class.validationMessages.length.tooLong + " (max=" + max + ")";
+            return this.Class.validationMessages.lengthLong + " (max=" + max + ")";
       });
    },
 

--- a/model/validations/validations.js
+++ b/model/validations/validations.js
@@ -78,13 +78,21 @@ $.extend($.Model, {
    /**
     * @attribute validationMessages
     * @parent jquery.model.validations
-    * The default validation error messages that will be returned by the 
-    * builtin validation methods. These can be overwritten by assigning
-    * new messages to $.Model.validationMessages in your application setup.
+    * The default validation error messages that will be returned by the builtin
+    * validation methods. These can be overwritten by assigning new messages
+    * to $.Model.validationMessages.&lt;message> in your application setup.
     * 
-    * It is important to ensure that jquery/model/validations is included
-    * with steal before overwriting the messages otherwise the changes will
-    * be lost once it is loaded by steal later.
+    * The following messages are available:
+    *  * format
+    *  * inclusion
+    *  * lengthShort
+    *  * lengthLong
+    *  * presence
+    *  * range
+    * 
+    * It is important to ensure that you steal jquery/model/validations 
+    * before overwriting the messages, otherwise the changes will
+    * be lost once steal loads it later.
     */
    validationMessages : {
        format      : "Is invalid",


### PR DESCRIPTION
I wanted to change the validation error message for the required field validator without having to specify it in every model; so I moved the default messages into a $.Model class attribute rather than having them defined in the built-in validations functions. Now the messages can be changed by writing a new string to $.Model.validationMessages._(msg)_ in your application config.

E.g. for my case I do:

`$.Model.validationMessages.presence = "Required field"`
