### PR TITLE
fix withinBox offset cache and fix old _setProperty function when a new model instance is created

### DIFF
--- a/dom/within/within.js
+++ b/dom/within/within.js
@@ -65,7 +65,7 @@ $.fn.withinBox = function(left, top, width, height, cache){
 
         if(this == document.documentElement) return  this.ret.push(this);
 
-        var offset = cache ? jQuery.data(this,"offset", q.offset()) : q.offset();
+        var offset = cache ? jQuery.data(this,"offset") || jQuery.data(this,"offset", q.offset()) : q.offset();
 
         var ew = q.width(), eh = q.height();
 

--- a/model/model.js
+++ b/model/model.js
@@ -1331,7 +1331,7 @@ steal('jquery/class', 'jquery/lang/string', function() {
 					};
 
 				// if we have a setter
-				if ( this[setName] &&
+				if ( !this._init && this[setName] &&
 				// call the setter, if returned value is undefined,
 				// this means the setter is async so we 
 				// do not call update property and return right away


### PR DESCRIPTION
Hi,
Old _setProperty function ( now it is included in attr function why? ) is fired , when a model instance is created. I think this is caused an extra server request problem while using asynchronous setters ( ajax call ).

Thanks,
Safak
