### PR TITLE
dom/fixture: Fixed failing create when findAll == create URL

### DIFF
--- a/dom/fixture/fixture.js
+++ b/dom/fixture/fixture.js
@@ -545,7 +545,7 @@ steal('jquery/dom',
 				var item = make(i, items);
 
 				if (!item.id ) {
-					item.id = i;
+					item.id = i + 1;
 				}
 				items.push(item);
 			}

--- a/dom/fixture/fixture.js
+++ b/dom/fixture/fixture.js
@@ -130,10 +130,12 @@ steal('jquery/dom',
 			}
 			return -1;
 		},
-		// overwrites the settings fixture if an overwrite matches
+		// Overwrites the settings fixture if an overwrite matches, but maintains the -restCreate, 
+		// Update or Delete function names even when the overwrite URL is found (which happens 
+		// when the URL for that method is the same as that of findAll, commom for -restCreate).
 		overwrite = function(settings){
 			var index = find(settings);
-			if(index > -1){
+			if(index > -1 && !/^-rest/.test(settings.fixture)){
 				settings.fixture = overwrites[index].fixture;
 				return $fixture._getData(overwrites[index].url, settings.url)
 			}

--- a/dom/fixture/fixture_test.js
+++ b/dom/fixture/fixture_test.js
@@ -23,6 +23,37 @@ test("static fixtures", function(){
 	},'json');
 })
 
+test("static model fixtures where findAll and create have the same URL", function(){
+    $.Model('Fixture.Test.Model', {
+        findAll : "/fixture/test/model",
+        create  : "/fixture/test/model",
+        // Since these methods usually specify the id and thus differ the error does not occur:
+        findOne : "/fixture/test/model/id/{id}", 
+        update  : "/fixture/test/model/id/{id}",
+        destroy : "/fixture/test/model/id/{id}"
+    }, 
+    {});
+
+	$.fixture("/fixture/test/model", "//jquery/dom/fixture/fixtures/test.json");
+
+	stop();
+    Fixture.Test.Model.findAll({}, function(models) {
+        ok(models.length);
+        equals(models[0].sweet,"ness","findAll works");
+        start();
+    });
+
+    var testModel = new Fixture.Test.Model();
+    testModel.sweet = "ness";
+    stop();
+    testModel.save(function(savedModel) {
+        ok(savedModel,"A model instance was returned")
+        ok(savedModel.id,"Model id was assigned")
+        equals(savedModel.sweet,"ness","Model attributed saved.")
+        start();
+    });
+})
+
 test("dynamic fixtures",function(){
 	stop();
 	$.fixture.delay = 10;


### PR DESCRIPTION
In dom/fixture the `overwrite()` method replaced the "-restCreate" function name on the `settings` object when the _create_ and _findAll_ URLs of a model were the same. Added a test for "-restXX" function names which are now left unchanged.
