### PR TITLE
Fixed $.Model.restore(true) overwriting associated (nested) models with plain objects

### DIFF
--- a/model/backup/backup.js
+++ b/model/backup/backup.js
@@ -105,6 +105,8 @@ See this in action:
 	    * @parent jquerymx.model.backup
 	    * Returns if the instance needs to be saved.  This will go
 	    * through associations too.
+	    * @param {Boolean} [checkAssociations] Whether attributes which are nested models or 
+	    * objects are also checked.
 	    * @return {Boolean} true if there are changes, false if otherwise
 	    */
 	   isDirty: function(checkAssociations) {
@@ -119,6 +121,8 @@ See this in action:
 		 * @function jQuery.Model.prototype.restore
 		 * @parent jquery.model.backup
 		 * restores this instance to its backup data.
+		 * @param {Boolean} [restoreAssociations] Whether attributes which are nested models or 
+		 * objects are also restored.
 		 * @return {model} the instance (for chaining)
 		 */
 		restore: function(restoreAssociations) {

--- a/model/model.js
+++ b/model/model.js
@@ -1404,6 +1404,13 @@ steal('jquery/class', 'jquery/lang/string', function() {
 				args, globalArgs, callback = success,
 				list = Class.list;
 
+            // If the property is a nested model, assign the value(s) using its attrs method
+            // if the new value is an object.
+            if (this._isModel(property) && $.isPlainObject(value)) {
+                this[property].attrs( value );
+                return;
+            }
+            
 			// set the property value
 			// notice that even if there's an error
 			// property values get set
@@ -1452,6 +1459,16 @@ steal('jquery/class', 'jquery/lang/string', function() {
 
 		},
 
+        /**
+         * Determine whether a property of this model is an association, i.e. another nested model.
+         * @hide
+         * @param {String} prop The property to test.
+         * @return {Boolean} Is it a model or not.
+         */
+        _isModel : function(prop) {
+            return !!(this[prop] && this[prop].Class && this[prop].Class._models);
+        },
+		
 		/**
 		 * Removes an attribute from the list existing of attributes. 
 		 * Each attribute is set with [jQuery.Model.prototype.attr attr].


### PR DESCRIPTION
Currently when backup/restore is used to restore a model with the _restoreAssociations_ option the nested model is lost because it is overwritten by the plain object from the store. I propose checking whether the current property is a nested model and in that case setting its values with its own `attrs()` method. This preserves the nested model and also causes it to trigger the appropriate update events etc.
#### Two things though:
- I'm not sure whether it's OK to return early after setting the nested model values, but it seems to me that the nested model will handle everything that's necessary.
- There may be a better way to test whether a property is a nested model.
