### PR TITLE
Clarify project name in README file.

### DIFF
--- a/README
+++ b/README
@@ -10,15 +10,15 @@ A.  How to get (and contribute) JMVC
            http://github.com/jupiterjs/steal     and 
            http://github.com/jupiterjs/jquerymx
   
-  3.  Add steal and javascriptmvc as submodules of your project...
+  3.  Add steal and jquerymx as submodules of your project...
            git submodule add git@github.com:_YOU_/steal.git steal
            git submodule add git@github.com:_YOU_/jquerymx.git jquery
            
-      * Notice javascriptmvc is under the jquery folder
+      * Notice jquerymx is under the jquery folder
   
   4.  Learn a little more about submodules ...
            http://johnleach.co.uk/words/archives/2008/10/12/323/git-submodules-in-n-easy-steps
            
-  5.  Make changes in steal or jmvc, and push them back to your fork.
+  5.  Make changes in steal or jquerymx, and push them back to your fork.
   
   6.  Make a pull request to your fork.


### PR DESCRIPTION
Similar to change in the javascriptmvc README file, this clarifies the project name referred to as jquerymx instead of the more general javascriptmvc. 
