### PR TITLE
Fixed a mistake in the documentation example of $.Model.prototype.models...

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -974,7 +974,7 @@ steal('jquery/class', 'jquery/lang/string', function() {
 		 * 
 		 *     $.Model('Person',{
 		 *       models : function(data){
-		 *         this._super(data.ballers);
+		 *         return this._super(data.ballers);
 		 *       }
 		 *     },{})
 		 * 


### PR DESCRIPTION
....

The 'return' was missing here (line 976):

```
     *     $.Model('Person',{
     *       models : function(data){
     *         return this._super(data.ballers);
     *       }
     *     },{})
```
