### PR TITLE
Breaking test for view helpers

### DIFF
--- a/view/ejs/ejs_test.js
+++ b/view/ejs/ejs_test.js
@@ -112,7 +112,7 @@ test("helpers", function() {
 	$.EJS.Helpers.prototype.elementHelper = function()
 	{
 		return function(el) {
-			$(el).html('Simple');
+			el.innerHTML = 'Simple';
 		}
 	}
 	
@@ -120,9 +120,10 @@ test("helpers", function() {
 	var compiled = new $.EJS({text: text}).render() ;
 	equals(compiled, "<div>Simple</div>");
 	
-	text = "<div <%= elementHelper() %>></div>";
+	text = "<div id=\"hookup\" <%= elementHelper() %>></div>";
 	compiled = new $.EJS({text: text}).render() ;
-	equals(compiled, "<div>Simple</div>");
+	$('#qunit-test-area').append($(compiled));
+	equals($('#hookup').html(), "Simple");
 });
 
 })

--- a/view/ejs/ejs_test.js
+++ b/view/ejs/ejs_test.js
@@ -103,4 +103,26 @@ test("easy hookup", function(){
 	ok( div.find('div').hasClass('yes'), "has yes" )
 });
 
+test("helpers", function() {
+	$.EJS.Helpers.prototype.simpleHelper = function()
+	{
+		return 'Simple';
+	}
+	
+	$.EJS.Helpers.prototype.elementHelper = function()
+	{
+		return function(el) {
+			$(el).html('Simple');
+		}
+	}
+	
+	var text = "<div><%= simpleHelper() %></div>";
+	var compiled = new $.EJS({text: text}).render() ;
+	equals(compiled, "<div>Simple</div>");
+	
+	text = "<div <%= elementHelper() %>></div>";
+	compiled = new $.EJS({text: text}).render() ;
+	equals(compiled, "<div>Simple</div>");
+});
+
 })


### PR DESCRIPTION
It seems as if the view blocks broke the support for helpers that work on an element attached to $.EJS.Helpers.prototype, breaking test attached.
