### PR TITLE
steal.dev.warn on empty models

### DIFF
--- a/model/model.js
+++ b/model/model.js
@@ -1007,7 +1007,7 @@ steal('jquery/class', 'jquery/lang/string', function() {
 				// get the object's data
 				instancesRawData.data),
 				// the number of items
-				length = raw.length,
+				length = raw ? raw.length : null,
 				i = 0;
 
 			//@steal-remove-start


### PR DESCRIPTION
## Steps to reproduce:
1. Return a models fixture with an object instead of an array
## Result:

try/catch on jquery.js #7371 fails, preventing the informative steal.dev.warn on model.js #1015 from displaying in console.
## Expected result:

steal.dev.warn on model.js #1015 reports that the models is empty and should be a model.
