### PR TITLE
Fixture does not return correct datatype when error is thrown

### DIFF
--- a/dom/fixture/fixture.js
+++ b/dom/fixture/fixture.js
@@ -96,6 +96,11 @@ steal('jquery/dom',
 					if(typeof response[0] != 'number'){
 						response.unshift(200,"success")
 					}
+
+					//If an error occur, force datatype to text as json will not work
+					if(response[0] >= 400 && response[0] <= 599){
+						next = 'text';
+					}
 					
 					// make sure we provide a response type that matches the first datatype (typically json)
 					if(!response[2] || !response[2][next]){


### PR DESCRIPTION
jQuery ajaxTransport does not accept datatype json when you return an error, leaving responseText empty.

```
$.fixture('POST /api/links', function() {
    if(!data.Text)  return [403, "Forbidden", { text:  'The field Title is required.'} , {}];
            //etc
});
```

Fixture will modify this and send the following to ajaxTransport

403, 'Forbidden', {json:{text:'The field Title is required. ' }}, {}

While it should be

403, 'Forbidden', {text:'The field Title is required. ' }, {}

That way when you do 

```
myrequest.fail(function(jqXHR){
    console.log(jqXHR.responseText ) //Not undefined
});
```
