### PR TITLE
Fix problems with EJS loading on Internet Explorer

### DIFF
--- a/view/ejs/ejs.js
+++ b/view/ejs/ejs.js
@@ -528,7 +528,7 @@ steal('jquery/view', 'jquery/lang/string/rsplit').then(function( $ ) {
 					out: 'try { with(_VIEW) { with (_CONTEXT) {' + template + " "+finishTxt+"}}}catch(e){e.lineNumber=null;throw e;}"
 				};
 			//use eval instead of creating a function, b/c it is easier to debug
-			myEval.call(out, 'this.fn = (function(_CONTEXT,_VIEW){' + out.out + '});\r\n//@ sourceURL=' + name + ".js");
+			myEval.call(out, 'this.fn = (function(_CONTEXT,_VIEW){' + out.out + '});\r\n//@ sourceURL="' + name + '".js');
 
 			return out;
 		};


### PR DESCRIPTION
See http://forum.javascriptmvc.com/topic/ie-only-errors-view-name-ejs-is-undefined-breaks-loading.

This is a problem with v3.2.2 and v3.2.3 at least.
