### PR TITLE
Exception when not using steal during ajax call

### DIFF
--- a/dom/fixture/fixture.js
+++ b/dom/fixture/fixture.js
@@ -35,7 +35,10 @@ steal('jquery/dom',
 			var url = settings.fixture;
 			
 			if (/^\/\//.test(url) ) {
-				url = steal.root.mapJoin(settings.fixture.substr(2))+'';
+				var sub = settings.fixture.substr(2) + '';
+				url = typeof steal === "undefined" ? 
+					url = "/" + sub : 
+					steal.root.mapJoin(sub) +'';
 			}
 			//!steal-remove-start
 			steal.dev.log("looking for fixture in " + url);


### PR DESCRIPTION
There was an undefined check missing while assembling the url for the request. I just adjusted the code to use the same mechanism as a few lines before.
