### PR TITLE
Fixed tap so that quick horizontal/vertical swipes did not cause tap events

### DIFF
--- a/event/tap/tap.js
+++ b/event/tap/tap.js
@@ -32,7 +32,7 @@ $.event.setupHelper( ["tap"], touchStartEvent, function(ev){
 	
 	function upHandler(event){
 		stop = data(event);
-		if ((Math.abs( start.coords[0] - stop.coords[0] ) < 10) ||
+		if ((Math.abs( start.coords[0] - stop.coords[0] ) < 10) &&
 		    ( Math.abs( start.coords[1] - stop.coords[1] ) < 10) ){
 			$.each($.event.find(delegate, ["tap"], selector), function(){
 				this.call(entered, ev, {start : start, end: stop})


### PR DESCRIPTION
We noticed while working on a bug in MindTap on the iPad that the tap event would fire if a swipe happened that was close in either the X or Y direction, where it should be both X AND Y that need to be close together. Here's our proposed fix.
