### PR TITLE
Fixed a bug where tests were not starting due to an undefined error

### DIFF
--- a/dom/route/route.js
+++ b/dom/route/route.js
@@ -382,7 +382,9 @@ function( $ ) {
 				onready = false;
 			}
 			if( val === true || onready === true ) {
-				setState();
+				if (typeof(setState) !== 'undefined') {
+					setState();
+				}
 			}
 			return $.route;
 		},


### PR DESCRIPTION
At random times, the tests would throw an 'undefined' error and wouldn't start. Me and other colleagues had to keep refreshing the page multiple times until the tests would start, which was annoying and counter productive
